### PR TITLE
add permission for tagging by CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,15 @@ name: Release
 on:
   push:
     branches: ["main"]
+
 jobs:
   tagpr:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+      actions: write
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 


### PR DESCRIPTION
On tagpr Action, required `action:write` permission for tagging.